### PR TITLE
Protect import of seaborn and statsmodels

### DIFF
--- a/mpoints/plot_tools.py
+++ b/mpoints/plot_tools.py
@@ -1,8 +1,14 @@
 import numpy as np
 import matplotlib.pyplot as plt
 import os
-import seaborn
-import statsmodels.tsa.stattools as stattools
+try:
+    import seaborn
+except Exception as e:
+    print('WARNING: Could not import seaborn')
+try:
+    import statsmodels.tsa.stattools as stattools
+except Exception as e:
+    print('WARNING: Could not import statsmodels')
 from matplotlib.colors import ListedColormap
 import copy
 import bisect


### PR DESCRIPTION
The module `plot_tools` uses `seaborn` and `statsmodels`, which are not listed as dependencies in `pyproject.toml` and are not strictly essential for `mpoints`. 
This PR proposes to wrap the import of `seaborn` and `statsmodels` in `try..except` construct. 